### PR TITLE
added required "owner" field which was causing errors registering the…

### DIFF
--- a/templates/spring-boot-app/template.yaml
+++ b/templates/spring-boot-app/template.yaml
@@ -56,6 +56,11 @@ spec:
           title: Project Name/Tag
           type: string
           default: springboot-demo
+        owner:
+          title: Owner (Team or User)
+          type: string
+          description: The Backstage entity owner in 'kind:default/name' format (e.g., group:default/team-a)
+          ui:autofill: user:$$user.entity.namespace/$$user.entity.name
       required:
         - orgName
         - repoName

--- a/templates/spring-boot-app/template.yaml
+++ b/templates/spring-boot-app/template.yaml
@@ -64,6 +64,7 @@ spec:
         - projectName
         - clusterid
         - apikey
+        - owner
     - title: Provide Information about deployment targets 
       properties:
         namespace:
@@ -117,7 +118,7 @@ spec:
           sourceControl: github.com
           backendport: ${{ parameters.backendport }}
           frontendport: ${{ parameters.frontendport }}
-          owner: ${{ parameters.orgName }}
+          owner: ${{ parameters.owner }}
           applicationType: service
           description: ${{ parameters.description }}
           lifecycle: experimental


### PR DESCRIPTION
The scaffolding template seems to be missing a key piece of information needed to generate the required owner field in the catalog−info.yaml. While passing an owner value to the fetch:template action, RHDH is not collecting the appropriate owner reference from the user.

<img width="1472" height="485" alt="image" src="https://github.com/user-attachments/assets/7c1a5d25-8597-480b-a58f-12526e7ada9a" />

```
[2m2025-10-09T23:21:35.164Z[22m [34mscaffolder[39m [32minfo[39m scaffolder.task [36misAuditEvent[39m=true [36meventId[39m="task" [36mseverityLevel[39m="medium" [36mactor[39m={"actorId":"plugin:scaffolder"} [36mrequest[39m=undefined [36mmeta[39m={"actionType":"execution","taskParameters":{"orgName":"bugbiteme","repoName":"spring-boot-react-app-1","repoVisibility":"public","description":"Test React APP using RHDH Templates","backendport":7890,"frontendport":3000,"projectName":"springboot-demo","apikey":"608cd27fc0e125dba91b98386d089359","clusterid":"xsgv2","namespace":"demo-project","argocdServer":"openshift-gitops-server.openshift-gitops.svc:80","argocdUsername":"admin","argocdPassword":"NlqSGkRYJ9UW2sc1ZzeOjvFQ6EIMron0"},"templateRef":"template:default/spring-boot-weather-api-backend"} [36merror[39m="ResponseError: Request failed with 400 Bad Request" [36mstatus[39m="failed"
```